### PR TITLE
Do not include debug symbols in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,4 @@ chumsky = "0.9"
 lto = true
 codegen-units = 1
 panic = "abort"
-debug = true
+debug = "line-tables-only"


### PR DESCRIPTION
Having line tables is enough for backtraces to work.